### PR TITLE
GitHub Issue #9: Miscellaneous small changes from leadership meeting

### DIFF
--- a/site/src/pages/beautification.md
+++ b/site/src/pages/beautification.md
@@ -14,14 +14,13 @@ Roles and Duties
 
 ## Roles and Duties
 
-* Beautification Projects: Organize and oversee projects aimed at improving the aesthetic appeal of the neighborhood, such as landscaping and public art installations.
 * Community Events: Plan and facilitate events that foster community spirit and interaction among residents.
 * Volunteer Coordination: Recruit and manage volunteers for beautification and community-building activities.
 * Resource Management: Identify resources and funding opportunities to support beautification efforts.
 
 ----
 
-Currently our biggest community event is National Night Out. We participated in it last year and will do so again this year. It will most likely be located at the Club again. Joyce Collier is our liaison with the Club and has made several meetings of our association there in the past year possible. 
+Currently our biggest community event is National Night Out. We participated in it last year and will do so again this year. 
 
 If you are interested in planning and facilitating community events, please contact us at ranchostna@gmail.com. Attention of Community Building Committee.
 

--- a/site/src/pages/community-action.md
+++ b/site/src/pages/community-action.md
@@ -17,19 +17,20 @@ The Community Action Committee aims to mobilize residents to address local issue
 
 ----
 
-We are currently in the process of gathering information regarding several issues that concern our neighborhood. Part of that is a discussion about the equal distribution of living spaces for unhoused people in San Jose at our next general meeting. 
+We are currently in the process of gathering information regarding several issues that concern our neighborhood.
 
 We also compiled a list of government contacts for those officials who are responsible for our neighborhood.  Feel free to use this resource to contact these officials.
 
 
-* [George Casey  District 10 City of San Jose](https://www.sjdistrict10.org/)
-* [Matt Mahan Mayor of San Jose](https://www.sjmayormatt.com/)
-* [Sylvia Arenas Supervisor District 1 Santa Clara County](https://d1.santaclaracounty.gov/home)
-* [Gail Pellerin Assembly member District 28 State of CA](https://a28.asmdc.org/)
-* [Jimmy Panetta US Representative (Congressman in the House) CA District 19](https://panetta.house.gov/)
-* [Alex Padilla, Senator of CA](https://www.padilla.senate.gov/)
-* [Adam Schiff, Senator of CA](https://www.schiff.senate.gov/)
-* [Gavin Newsom Governor of CA](https://www.gov.ca.gov/)
-* [Rob Bonta Attorney General of CA](https://oag.ca.gov/about)
+* [George Casey, District 10 City of San Jose](https://www.sjdistrict10.org/)
+* [Matt Mahan, Mayor of San Jose](https://www.sjmayormatt.com/)
+* [Sylvia Arenas, Supervisor District 1 Santa Clara County](https://d1.santaclaracounty.gov/home)
+* [Gail Pellerin, State Assembly Member District 28](https://a28.asmdc.org/)
+* [Dave Cortese, State Senator District 15](https://sd15.senate.ca.gov/)
+* [Jimmy Panetta, US Representative District 19](https://panetta.house.gov/)
+* [Alex Padilla, Senator](https://www.padilla.senate.gov/)
+* [Adam Schiff, Senator](https://www.schiff.senate.gov/)
+* [Gavin Newsom, Governor](https://www.gov.ca.gov/)
+* [Rob Bonta, Attorney General](https://oag.ca.gov/about)
 
 If you are interested in local neighborhood issues and advocating, please contact us at ranchostna@gmail.com. Attention of Community Action Committee.

--- a/site/src/pages/crime.md
+++ b/site/src/pages/crime.md
@@ -17,9 +17,9 @@ The Crime & Neighborhood Watch Committee is dedicated to promoting safety and se
 
 ----
 
-We started to form Neighborhood Watches for several streets within our Neighborhood Association. This is an ongoing process. Once Neighborhood Watches form, they receive signs from the city.
+We started to form Neighborhood Watch Groups for several streets within our Neighborhood Association. This is an ongoing process. Once Neighborhood Watch Groups form, they receive signs from the city.
 
-If you are interested in Crime Prevention and Neighborhood Watch Groups, please contact us at ranchostna@gmail.com . Attention of Crime Prevention and Neighborhood Watch Committee. 
+If you are interested in Crime Prevention and Neighborhood Watch Groups, please contact us at ranchostna@gmail.com. Attention of Crime and Neighborhood Watch Committee. 
 
 **Installing a Neighborhood Watch sign:**
 

--- a/site/src/pages/emergency.md
+++ b/site/src/pages/emergency.md
@@ -15,10 +15,12 @@ The Emergency Preparedness Committee equips residents with the knowledge and res
 
 ----
 
-Several of our members have graduated from the [CERT basic training](https://www.sanjoseca.gov/your-government/departments-offices/office-of-the-city-manager/emergency-management/be-trained/community-emergency-response-team-training). A few more are in the process of getting certified. This is an ongoing process, and the more people in the community and neighborhood know how to prepare for and react in a disaster, the better. Michael Bryant coordinates and tracks our participants. 
+Several of our members have graduated from the [CERT basic training](https://www.sanjoseca.gov/your-government/departments-offices/office-of-the-city-manager/emergency-management/be-trained/community-emergency-response-team-training). A few more are in the process of getting certified. This is an ongoing process, and the more people in the community and neighborhood that know how to prepare for and react in a disaster, the better.
 
-If you are interested in emergency preparedness, please contact us at ranchostna@gmail.com . Attention of Emergency Preparedness Committee. 
+If you are interested in emergency preparedness, please contact us at ranchostna@gmail.com. Attention of Emergency Preparedness Committee. 
 
 ----
 
 ![](../images/emergency-operations-center.png)
+
+(Photo courtesy of Colin Tanner)

--- a/site/src/pages/events.md
+++ b/site/src/pages/events.md
@@ -5,14 +5,6 @@ title: "RSTNA: Events"
 
 # Upcoming Events
 
-## CERT 5K Family Fun Run - Mar 28, 2026 (free)
-
-See the flyer for more information and to register.  This event is sponsored by District 10 Councilmember George Casey and CERT (Community Emergency Response Teams).
- 
-[Flyer](https://www.sjdistrict10.org/events/cert-5k-family-fun-run)
-
-
-
 ## National Night Out - Aug 4, 2026
 
 The best way to build a safer community is to know your neighbors and your surroundings.  National Night Out provides a great opportunity to bring police and neighbors together under positive circumstances.
@@ -25,6 +17,10 @@ Councilmember George Casey and RSTNA are sponsoring a Dumpster Day for the local
 
 The October meeting will provide RSTNA Committee updates and a presentation - topic to be determined. More information to come.
 
+## District 10 Events
+
+Visit the [District 10 webpage](https://www.sjdistrict10.org/events) to find out about upcoming events in our District.
+
 ----
 
 # Past Meetings
@@ -33,15 +29,17 @@ For RSTNA history and earlier events, please see [History](../history).
 
 ## General Meeting - Feb 2026
 
-The February meeting included RSTNA Committee updates and a presentation on the VTA Safe Parking Site.  [Minutes of the Feb 2026 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=8710&tem=MinutesDetails.chtml&mnm=R9B5P4Q2). Presentation Slides - Safe Parking
+The February meeting included RSTNA Committee updates and a presentation on the VTA Safe Parking Site.
+* [Minutes of the Feb 2026 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=8710&tem=MinutesDetails.chtml&mnm=R9B5P4Q2)
+* [Presentation Slides - Safe Parking](https://docs.google.com/presentation/d/1ztMnPkTu8qkj8DIO9xOCZhEQ645H3b_Pk7-1oVwsaAg/edit?slide=id.g3aeb524acb5_2_75#slide=id.g3aeb524acb5_2_75)
 
 
 ## General Meeting – Oct 2025
 
 The October meeting included RSTNA Committee updates and a presentation on Earthquake Preparedness.  
 
-* [Minutes of the Oct 2025 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=6858&tem=MinutesDetails.chtml&mnm=A5N5O4Q2). 
-* [Presentation Slides Emergency Preparedness](../RSTNA-Preparedness-2025-10.pdf)
+* [Minutes of the Oct 2025 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=6858&tem=MinutesDetails.chtml&mnm=A5N5O4Q2)
+* [Presentation Slides - Emergency Preparedness](../RSTNA-Preparedness-2025-10.pdf)
 
  
 ## General Meeting – Jun 2025

--- a/site/src/pages/goals.md
+++ b/site/src/pages/goals.md
@@ -33,9 +33,9 @@ The [Communications Committee](../communications) supports the association's mis
 
 The [Community Action Committee](../community-action) aims to mobilize residents to address local issues and advocate for improvements in neighborhood services and infrastructure, in line with our mission to enhance the quality of life.
 
-## Community Building/Beautification Committee
+## Community Building Committee
 
-The [Community Building Committee](../beautification) focuses on enhancing the physical and social environment, fostering connections among neighbors as outlined in our mission.
+The [Community Building Committee](../beautification) focuses on enhancing the social environment, fostering connections among neighbors as outlined in our mission.
 
 ## Crime & Neighborhood Watch Committee
 

--- a/site/src/pages/history.md
+++ b/site/src/pages/history.md
@@ -9,8 +9,10 @@ The Rancho Santa Teresa Neighborhood Association was founded in 2025 holding its
 
 ## General Meeting - Feb 2026
 
-The February meeting included RSTNA Committee updates and a presentation on the VTA Safe Parking Site.  [Minutes of the Feb 2026 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=8710&tem=MinutesDetails.chtml&mnm=R9B5P4Q2). Presentation Slides - Safe Parking
+The February meeting included RSTNA Committee updates and a presentation on the VTA Safe Parking Site.
 
+* [Minutes of the Feb 2026 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=8710&tem=MinutesDetails.chtml&mnm=R9B5P4Q2)
+* [Presentation Slides - Safe Parking](https://docs.google.com/presentation/d/1ztMnPkTu8qkj8DIO9xOCZhEQ645H3b_Pk7-1oVwsaAg/edit?slide=id.g3aeb524acb5_2_75#slide=id.g3aeb524acb5_2_75)
 
 
 ## Neighborhood Watch Program - Dec 2025
@@ -25,8 +27,8 @@ Councilmember George Casey and RSTNA sponsored a Dumpster Day for the local comm
 
 The October meeting included RSTNA Committee updates and a presentation on Earthquake Preparedness.  
 
-* [Minutes of the Oct 2025 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=6858&tem=MinutesDetails.chtml&mnm=A5N5O4Q2). 
-* [Presentation Slides Emergency Preparedness](../RSTNA-Preparedness-2025-10.pdf)
+* [Minutes of the Oct 2025 meeting](https://s06.circleweaver.com/weaver/t/rstna/main-committee/MeetPrint.htm?id=6858&tem=MinutesDetails.chtml&mnm=A5N5O4Q2)
+* [Presentation Slides - Emergency Preparedness](../RSTNA-Preparedness-2025-10.pdf)
 
 ## Neighborhood Watch Program - Oct 2025
 

--- a/site/src/pages/leadership.md
+++ b/site/src/pages/leadership.md
@@ -18,13 +18,7 @@ title: "RSTNA: Leadership"
 ## Ute Orgassa, Secretary / Communications
 
 
-&nbsp;
-
-## Joyce Collier, Community Building
-
-&nbsp;
-
-## Keith Swenson, Webmaster
+# Committee Leads
 
 &nbsp;
 
@@ -32,7 +26,19 @@ title: "RSTNA: Leadership"
 
 &nbsp;
 
-## Mike Bryant, Emergency Preparedness
+## Mike Bryant, Community Action
+
+&nbsp;
+
+## Keith Swenson, Webmaster
+
+&nbsp;
+
+## Open, Community Building
+
+&nbsp;
+
+## Open, Emergency Preparedness
 
 &nbsp;
 

--- a/site/src/pages/notes.md
+++ b/site/src/pages/notes.md
@@ -3,15 +3,15 @@ slug: "/notes"
 title: "RSTNA: Notes"
 ---
 
-# Notes
+# Notes & Tidbits
 
-## Privacy - DROP (Delete Request and Opt-out Program) - privacy.ca.gov/drop 
+## Privacy - DROP (Delete Request and Opt-out Program) 
 
-Californians can submit one, simple request to stop all data brokers from selling their personal information.  Data brokers, who often collect and trade personal information without people’s knowledge, must begin processing these requests by August 2026.
+Californians can submit one, simple request to stop all data brokers from selling their personal information.  Data brokers, who often collect and trade personal information without people’s knowledge, must begin processing these requests by August 2026.  Visit https://privacy.ca.gov/drop to verify your California residency and send a deletion request.
 
 ## Emergency Preparedness - Personal Emergency Preparedness
 
-[Presentation Slides Emergency Preparedness](../RSTNA-Preparedness-2025-10.pdf)
+[Presentation Slides - Personal Emergency Preparedness](../RSTNA-Preparedness-2025-10.pdf)
 
 ## Emergency Preparedness - Recommended Earthquake Safety Actions
 


### PR DESCRIPTION
The following changes are in this PR, which covers a variety of small items brought up at the last couple of leadership meetings:

goals.md (About)
  -- remove Beautification (committee title)
  
beautification.md (Community Building Committee)
  -- remove beautification under roles and duties
  -- remove Joyce's name
  
crime.md (Crime and Neighborhood Watch Committee)
  -- Change Neighborhood Watches to Neighborhood Watch Groups
  
community-action.md (Community Action Committee)
  -- add Dave Cortese
  -- formatting
  
emergency.md (Emergency Preparedness Committee)
  -- remove Michael's name
  -- add photo credit
  
leadership.md (People)
  -- remove Joyce
  -- Update Mike's role
  -- indicate open positions
  
notes.md (Notes)
  -- update title to include "& Tidbits"
  -- minor formatting for eprep link
  
events.md (Events)
  -- remove old event (Fun Run)
  -- add link to D10 upcoming events page
  -- formatting of past meetings
  -- added link to slides for Feb 2026 meeting
  
history.md (History)
  -- formatting of past meetings
  -- added link to slides for Feb 2026 meeting